### PR TITLE
Add product listing page

### DIFF
--- a/src/pages/ProductsPage.vue
+++ b/src/pages/ProductsPage.vue
@@ -1,0 +1,39 @@
+<template>
+  <q-page class="q-pa-md">
+    <q-table
+      :rows="products"
+      :columns="columns"
+      row-key="id"
+      flat
+    />
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+
+type Product = {
+  id: number;
+  name: string;
+  price: number;
+};
+
+const products = ref<Product[]>([]);
+
+const columns = [
+  { name: 'id', label: 'ID', field: 'id', align: 'left' },
+  { name: 'name', label: 'Name', field: 'name', align: 'left' },
+  { name: 'price', label: 'Price', field: 'price', align: 'left' }
+];
+
+onMounted(async () => {
+  try {
+    const res = await fetch('/api/products');
+    if (res.ok) {
+      products.value = await res.json();
+    }
+  } catch (err) {
+    console.error('Failed to load products', err);
+  }
+});
+</script>

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -4,7 +4,10 @@ const routes: RouteRecordRaw[] = [
   {
     path: '/',
     component: () => import('layouts/MainLayout.vue'),
-    children: [{ path: '', component: () => import('pages/IndexPage.vue') }],
+    children: [
+      { path: '', component: () => import('pages/IndexPage.vue') },
+      { path: 'products', component: () => import('pages/ProductsPage.vue') }
+    ],
   },
 
   // Always leave this as last one,


### PR DESCRIPTION
## Summary
- add ProductsPage view to show a table of products fetched from `/api/products`
- wire `/products` route

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867e6bb4158832dadfc948de89574a3