### PR TITLE
Add product search layout

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,43 +1,21 @@
 <template>
   <q-layout view="lHh Lpr lFf">
     <q-header elevated>
-      <q-toolbar>
-        <q-btn
-          flat
-          dense
-          round
-          icon="menu"
-          aria-label="Menu"
-          @click="toggleLeftDrawer"
-        />
-
-        <q-toolbar-title>
-          Quasar App
-        </q-toolbar-title>
-
-        <div>Quasar v{{ $q.version }}</div>
+      <q-toolbar class="q-pa-sm">
+        <q-input
+          filled
+          debounce="300"
+          v-model="searchTerm"
+          placeholder="Buscar producto por nombre o c\u00f3digo"
+          clearable
+          class="full-width"
+        >
+          <template #append>
+            <q-icon name="search" />
+          </template>
+        </q-input>
       </q-toolbar>
     </q-header>
-
-    <q-drawer
-      v-model="leftDrawerOpen"
-      show-if-above
-      bordered
-    >
-      <q-list>
-        <q-item-label
-          header
-        >
-          Essential Links
-        </q-item-label>
-
-        <EssentialLink
-          v-for="link in linksList"
-          :key="link.title"
-          v-bind="link"
-        />
-      </q-list>
-    </q-drawer>
 
     <q-page-container>
       <router-view />
@@ -46,57 +24,5 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
-import EssentialLink, { type EssentialLinkProps } from 'components/EssentialLink.vue';
-
-const linksList: EssentialLinkProps[] = [
-  {
-    title: 'Docs',
-    caption: 'quasar.dev',
-    icon: 'school',
-    link: 'https://quasar.dev'
-  },
-  {
-    title: 'Github',
-    caption: 'github.com/quasarframework',
-    icon: 'code',
-    link: 'https://github.com/quasarframework'
-  },
-  {
-    title: 'Discord Chat Channel',
-    caption: 'chat.quasar.dev',
-    icon: 'chat',
-    link: 'https://chat.quasar.dev'
-  },
-  {
-    title: 'Forum',
-    caption: 'forum.quasar.dev',
-    icon: 'record_voice_over',
-    link: 'https://forum.quasar.dev'
-  },
-  {
-    title: 'Twitter',
-    caption: '@quasarframework',
-    icon: 'rss_feed',
-    link: 'https://twitter.quasar.dev'
-  },
-  {
-    title: 'Facebook',
-    caption: '@QuasarFramework',
-    icon: 'public',
-    link: 'https://facebook.quasar.dev'
-  },
-  {
-    title: 'Quasar Awesome',
-    caption: 'Community Quasar projects',
-    icon: 'favorite',
-    link: 'https://awesome.quasar.dev'
-  }
-];
-
-const leftDrawerOpen = ref(false);
-
-function toggleLeftDrawer () {
-  leftDrawerOpen.value = !leftDrawerOpen.value;
-}
+import { searchTerm } from '../stores/search';
 </script>

--- a/src/pages/ProductsPage.vue
+++ b/src/pages/ProductsPage.vue
@@ -1,29 +1,33 @@
 <template>
   <q-page class="q-pa-md">
-    <q-table
-      :rows="products"
-      :columns="columns"
-      row-key="id"
-      flat
-    />
+    <q-table :rows="filteredProducts" :columns="columns" row-key="id" flat />
   </q-page>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, computed } from 'vue';
+import { searchTerm } from '../stores/search';
 
 type Product = {
   id: number;
   name: string;
+  barcode: string;
   price: number;
 };
 
 const products = ref<Product[]>([]);
 
+const sampleProducts: Product[] = [
+  { id: 1, name: 'Coca Cola', barcode: '1234567890123', price: 1.5 },
+  { id: 2, name: 'Pepsi', barcode: '2345678901234', price: 1.4 },
+  { id: 3, name: 'Agua', barcode: '3456789012345', price: 0.8 },
+];
+
 const columns = [
   { name: 'id', label: 'ID', field: 'id', align: 'left' },
   { name: 'name', label: 'Name', field: 'name', align: 'left' },
-  { name: 'price', label: 'Price', field: 'price', align: 'left' }
+  { name: 'barcode', label: 'Barcode', field: 'barcode', align: 'left' },
+  { name: 'price', label: 'Price', field: 'price', align: 'left' },
 ];
 
 onMounted(async () => {
@@ -31,9 +35,22 @@ onMounted(async () => {
     const res = await fetch('/api/products');
     if (res.ok) {
       products.value = await res.json();
+    } else {
+      products.value = sampleProducts;
     }
   } catch (err) {
     console.error('Failed to load products', err);
+    products.value = sampleProducts;
   }
+});
+
+const filteredProducts = computed(() => {
+  if (!searchTerm.value) {
+    return products.value;
+  }
+  const term = searchTerm.value.toLowerCase();
+  return products.value.filter(
+    (p) => p.name.toLowerCase().includes(term) || p.barcode.toLowerCase().includes(term),
+  );
 });
 </script>

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -1,0 +1,3 @@
+import { ref } from 'vue';
+
+export const searchTerm = ref('');


### PR DESCRIPTION
## Summary
- create a simple reactive store for search text
- redesign `MainLayout` to only show a product search bar
- load example products and filter them by name or barcode in `ProductsPage`

## Testing
- `npm test`
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_686800e58234832da4b0b2e0ad48d6da